### PR TITLE
config: Remove Pixel-Framework

### DIFF
--- a/config/common.mk
+++ b/config/common.mk
@@ -8,7 +8,6 @@ endif
 # Pixel additions
 ifeq ($(WITH_GMS),true)
 $(call inherit-product, vendor/google/overlays/ThemeIcons/config.mk)
-$(call inherit-product, vendor/pixel-framework/config.mk)
 $(call inherit-product, vendor/pixel-style/config/common.mk)
 
 # Don't dexpreopt prebuilts. (For GMS).


### PR DESCRIPTION
Since this is no longer being tracked, causes build issues with Pixel devices.